### PR TITLE
feat: transfer entire routing table instead of just the networks

### DIFF
--- a/lib/charms/ip_router_interface/v0/ip_router_interface.py
+++ b/lib/charms/ip_router_interface/v0/ip_router_interface.py
@@ -54,7 +54,6 @@ class SimpleIPRouteProviderCharm(ops.CharmBase):
         # Process the networks however you like
         implement_networks(all_networks)
         
-        
     def _action_get_routing_table(self, event: ops.ActionEvent):
         all_networks = self.RouterProvider.get_flattened_routing_table()
         event.set_results({"msg": json.dumps(all_networks)})
@@ -444,6 +443,7 @@ class RouterRequires(Object):
 
         try:
             existing_routing_table = self.get_routing_table()
+            existing_routing_table.pop(custom_network_name, None)
             for i, network_request in enumerate(requested_networks):
                 other_requested_networks = requested_networks[i + 1 :]
                 _validate_network(network_request, existing_routing_table)

--- a/lib/charms/ip_router_interface/v0/ip_router_interface.py
+++ b/lib/charms/ip_router_interface/v0/ip_router_interface.py
@@ -463,8 +463,8 @@ class RouterRequires(Object):
         router_relations = self.model.relations.get(self.relationship_name)
         validated_routing_table: RoutingTable = {}
         for relation in router_relations:
-            if networks := relation.data[relation.app].get("networks"):
-                routing_table_from_databag: RoutingTable = json.loads(networks)
+            if relation_data := relation.data[relation.app].get("networks"):
+                routing_table_from_databag: RoutingTable = json.loads(relation_data)
                 if not isinstance(json.loads(networks), dict):
                     logger.error(
                         "The router's routing table has been misconfigured. Can't build routing table."
@@ -503,8 +503,8 @@ class RouterRequires(Object):
         router_relations = self.model.relations.get(self.relationship_name)
         all_networks = []
         for relation in router_relations:
-            if networks := relation.data[relation.app].get("networks"):
-                routing_table_from_databag: RoutingTable = json.loads(networks)
+            if relation_data := relation.data[relation.app].get("networks"):
+                routing_table_from_databag: RoutingTable = json.loads(relation_data)
                 if not isinstance(routing_table_from_databag, dict):
                     logger.error(
                         "The router's routing table has been misconfigured. Can't build routing table."

--- a/lib/charms/ip_router_interface/v0/ip_router_interface.py
+++ b/lib/charms/ip_router_interface/v0/ip_router_interface.py
@@ -485,7 +485,7 @@ class RouterRequires(Object):
                         else:
                             validated_routing_table[network_name].append(network)
                 logger.debug(
-                    f"Read networks from app: (%s) and relation: (%s)",
+                    "Read networks from app: (%s) and relation: (%s)",
                     relation.app.name,
                     self.relationship_name,
                 )

--- a/lib/charms/ip_router_interface/v0/ip_router_interface.py
+++ b/lib/charms/ip_router_interface/v0/ip_router_interface.py
@@ -454,7 +454,7 @@ class RouterRequires(Object):
             logger.error(
                 "Exception (%s) occurred with network request. No routes were added.", e.args[0]
             )
-            return
+            raise
 
         for relation in ip_router_relations:
             network_name = custom_network_name if custom_network_name else relation.name

--- a/lib/charms/ip_router_interface/v0/ip_router_interface.py
+++ b/lib/charms/ip_router_interface/v0/ip_router_interface.py
@@ -106,11 +106,11 @@ class SimpleIPRouteRequirerCharm(ops.CharmBase):
 
     def _routing_table_updated(self, event: RoutingTableUpdatedEvent):
         # Get and process all of the available networks when they're updated
-        all_networks = self.RouterRequirer.get_all_networks()
+        all_networks = self.RouterRequirer.get_routing_table()
 
     def _action_get_all_networks(self, event: ops.ActionEvent):
         # Get and process all of the available networks any time you like
-        all_networks = self.RouterRequirer.get_all_networks()
+        all_networks = self.RouterRequirer.get_routing_table()
         event.set_results({"msg": json.dumps(all_networks)})
 
     def _action_request_network(self, event: ops.ActionEvent):

--- a/lib/charms/ip_router_interface/v0/ip_router_interface.py
+++ b/lib/charms/ip_router_interface/v0/ip_router_interface.py
@@ -442,13 +442,19 @@ class RouterRequires(Object):
         if len(ip_router_relations) == 0:
             raise RuntimeError("No ip-router relation exists yet.")
 
-        existing_routing_table = self.get_routing_table()
-        for i, network_request in enumerate(requested_networks):
-            other_requested_networks = requested_networks[i + 1 :]
-            _validate_network(network_request, existing_routing_table)
-            _validate_network(
-                network_request, {"other-requested-networks": other_requested_networks}
+        try:
+            existing_routing_table = self.get_routing_table()
+            for i, network_request in enumerate(requested_networks):
+                other_requested_networks = requested_networks[i + 1 :]
+                _validate_network(network_request, existing_routing_table)
+                _validate_network(
+                    network_request, {"other-requested-networks": other_requested_networks}
+                )
+        except (ValueError, KeyError) as e:
+            logger.error(
+                "Exception (%s) occurred with network request. No routes were added.", e.args[0]
             )
+            return
 
         for relation in ip_router_relations:
             network_name = custom_network_name if custom_network_name else relation.name

--- a/lib/charms/ip_router_interface/v0/ip_router_interface.py
+++ b/lib/charms/ip_router_interface/v0/ip_router_interface.py
@@ -196,10 +196,11 @@ class RouterRequirerCharmEvents(ObjectEvents):
 def _validate_network(network_request: Network, existing_routing_table: RoutingTable):
     """Validates the network configuration created by the ip-router requirer
 
-    The requested network must have all of the required fields, the gateway
-    has to be located within the network, and all of the routes need to have
-    a path through the top level network. The requested network must also be
-    unassigned by the provider.
+    The requested network must have all of the required keys as indicated in the
+    Network type ('gateway' and 'network'), the gateway has to be located within
+    the network, and all of the routes need to have a path through the top level
+    network. The requested network must also be previously unassigned by the
+    provider.
 
     Args:
         network_request:

--- a/lib/charms/ip_router_interface/v0/ip_router_interface.py
+++ b/lib/charms/ip_router_interface/v0/ip_router_interface.py
@@ -455,8 +455,7 @@ class RouterRequires(Object):
         """Fetches combined routing tables made available by ip-router providers
 
         Returns:
-            A list of objects of type `Network`. This list contains networks
-            from all ip-router providers that are integrated with the charm.
+            An object of type `RoutingTable` as defined in this file.
         """
         if not self.charm.unit.is_leader():
             return

--- a/lib/charms/ip_router_interface/v0/ip_router_interface.py
+++ b/lib/charms/ip_router_interface/v0/ip_router_interface.py
@@ -444,7 +444,7 @@ class RouterRequires(Object):
 
         existing_routing_table = self.get_routing_table()
         for i, network_request in enumerate(requested_networks):
-            other_requested_networks = requested_networks[:i] + requested_networks[i + 1 :]
+            other_requested_networks = requested_networks[i + 1 :]
             _validate_network(network_request, existing_routing_table)
             _validate_network(
                 network_request, {"other-requested-networks": other_requested_networks}

--- a/lib/charms/ip_router_interface/v0/ip_router_interface.py
+++ b/lib/charms/ip_router_interface/v0/ip_router_interface.py
@@ -89,7 +89,7 @@ class SimpleIPRouteRequirerCharm(ops.CharmBase):
         self.RouterRequirer = RouterRequires(charm=self)
         self.framework.observe(self.on.install, self._on_install)
         self.framework.observe(self.on.ip_router_relation_joined, self._on_relation_joined)
-        self.framework.observe(self.RouterProvider.on.routing_table_updated, self._routing_table_updated)
+        self.framework.observe(self.RouterRequirer.on.routing_table_updated, self._routing_table_updated)
 
         self.framework.observe(self.on.get_all_networks_action, self._action_get_all_networks)
         self.framework.observe(self.on.request_network_action, self._action_request_network)
@@ -411,7 +411,7 @@ class RouterRequires(Object):
         )
 
     def _router_relation_changed(self, event: RelationChangedEvent):
-        new_table = self.get_all_networks()
+        new_table = self.get_routing_table()
         self.on.routing_table_updated.emit({"networks": new_table})
 
     def request_network(self, networks: List[Network], custom_network_name: str = None) -> None:

--- a/lib/charms/ip_router_interface/v0/ip_router_interface.py
+++ b/lib/charms/ip_router_interface/v0/ip_router_interface.py
@@ -15,26 +15,32 @@ charmcraft fetch-lib charms.ip_router_interface.v0.ip_router_interface
 ```
 
 ### Provider charm
-This example provider charm is all we need to listen to ip-router requirer requests.
-The ip-router provider fulfills the routing function for multiple charms that are
-requirers of the ip-router interface. For that reason, this charm will continuously
-track and update all of the connected requirers and the networks and routes they've 
-requested, which it does in a routing table. As new charms are connected and disconnected
-to the relation, this routing table is automatically adds and removes the dependent
-networks.
+This example provider charm shows how the library could be utilized to provide
+ip routing functionality. From the point of view of the provider charm, it's possible to:
 
-The library handles the listening and synchronization for all of the ip-router network
-requests internally, which means as the charm author you don't need to worry about any
-of the business logic of validating or orchestrating the relation network.
+* Return the live routing table,
+* Observe whenever the routing table is updated
 
-You can also listen to the `routing_table_updated` event that is emitted after the 
-tables are synced.
+The library itself takes care of adding, removing, updating the networks requested,
+and the synchronization of the routing table between the requirers,
+which means as the author of the provider charm, there is no need to handle the 
+logic of the objects of type Network. 
 
+When reading the routing table directly, the following are guaranteed by the 
+library:
+
+* The networks that are available in the routing table are:
+    * Unique,
+    * Valid as described by the function _validate_network,
+    * Associated with a single requirer application
+
+You can also listen to the `routing_table_updated` event that is emitted after all of
+ the tables are synced, which guarantees that the routing table is updated at the moment.
 
 ```python
 import logging, json
 import ops
-from charms.ip_router_interface.v0.ip_router_interface import *
+from charms.ip_router_interface.v0.ip_router_interface import RouterProvides
 
 class SimpleIPRouteProviderCharm(ops.CharmBase):
 
@@ -49,16 +55,15 @@ class SimpleIPRouteProviderCharm(ops.CharmBase):
         self.unit.status = ops.ActiveStatus("Ready to Provide")
 
     def _routing_table_updated(self, event: RoutingTableUpdatedEvent):
+        # The table can be used automatically after updating 
         routing_table = event.routing_table
-
-        # Process the networks however you like
-        implement_networks(all_networks)
+        implement_networks(routing_table)
         
     def _action_get_routing_table(self, event: ops.ActionEvent):
-        all_networks = self.RouterProvider.get_flattened_routing_table()
+        # The table can be used on-demand
+        all_networks = self.RouterProvider.get_routing_table()
         event.set_results({"msg": json.dumps(all_networks)})
     
-
 
 if __name__ == "__main__":  # pragma: nocover
     ops.main(SimpleIPRouteProviderCharm)  # type: ignore
@@ -162,10 +167,7 @@ Network: TypeAlias = Dict[
     ],
 ]
 
-RoutingTable: TypeAlias = Dict[
-    str,  # Name of the application
-    List[Network],  # All networks for this application
-]
+RoutingTable: TypeAlias = Dict[str, Network]  # Name of the network  # A Dict of type Network
 
 
 class RoutingTableUpdatedEvent(EventBase):
@@ -204,9 +206,9 @@ def _validate_network(network_request: Network, existing_routing_table: RoutingT
     Args:
         network_request:
             An object of type `Network` that will be validated.
-        new_networks:
-            The rest of the networks to check if this one is mutually
-            exclusive to the rest of the subnets.
+        existing_routing_table:
+            The existing routing table. The given network will be checked to see
+            if it could be added to this object.
 
     Raises:
         ValueError:
@@ -238,32 +240,18 @@ def _validate_network(network_request: Network, existing_routing_table: RoutingT
         if route_gateway not in network:
             raise ValueError("There is no route to this destination from the network.")
 
-    for existing_network_list in existing_routing_table.values():
-        for existing_network in existing_network_list:
-            old_subnet = IPv4Network(existing_network["network"])
-            new_subnet = IPv4Network(network_request["network"])
+    for existing_network in existing_routing_table.values():
+        old_subnet = IPv4Network(existing_network["network"])
+        new_subnet = IPv4Network(network_request["network"])
 
-            if old_subnet.subnet_of(new_subnet) or old_subnet.supernet_of(new_subnet):
-                raise ValueError("This network has been defined in a previous entry.")
-
-
-def _network_name_taken(name: str, relations: List[Relation]) -> bool:
-    count = 0
-    for relation in relations:
-        if name == relation.data[relation.app].get("network-name"):
-            count += 1
-
-    if count > 1:
-        logger.error(
-            "There are multiple relations with the name (%s). Please change one or provide a custom network name.",
-            name,
-        )
-        return True
-    return False
+        if old_subnet.subnet_of(new_subnet) or old_subnet.supernet_of(new_subnet):
+            raise ValueError("This network has been defined in a previous entry.")
 
 
 class RouterProvides(Object):
-    """This class is used to manage the routing table of the router provider.
+    """This class is initialized by the ip-router provider to automatically
+    accept new network requests from ip-router requirers and synchronize all
+    requirers' databags with the new network topology.
 
     It's capabilities are to:
     * Build a Routing Table from all of the databags of the requirers with their
@@ -275,8 +263,8 @@ class RouterProvides(Object):
     Attributes:
         charm:
             The Charm object that instantiates this class.
-        relationship_name:
-            The name used for the relationship implementing the ip-router interface.
+        relation_name:
+            The name used for the relation implementing the ip-router interface.
             All requirers that integrate to this name are grouped into one routing table.
             "ip-router" by default.
     """
@@ -295,7 +283,7 @@ class RouterProvides(Object):
         )
 
     def _router_relation_changed(self, event: RelationChangedEvent):
-        """Resync the databags since there could have been a change in networks."""
+        """Update and sync the routing tables when a databag changes."""
         if not self.charm.unit.is_leader():
             return
         self._sync_routing_tables()
@@ -303,9 +291,7 @@ class RouterProvides(Object):
         self.on.routing_table_updated.emit({"networks": new_table})
 
     def _router_relation_departed(self, event: RelationDepartedEvent):
-        """If an application has completely departed the relation, remove it
-        from the routing table.
-        """
+        """Update and sync the routing tables if an application leaves."""
         if not self.charm.unit.is_leader():
             return
         self._sync_routing_tables()
@@ -313,40 +299,62 @@ class RouterProvides(Object):
         self.on.routing_table_updated.emit({"networks": new_table})
 
     def get_routing_table(self) -> RoutingTable:
-        """Build the routing table from all of the related databags. Relations
-        that don't have missing or invalid network requests will be ignored.
+        """Build the routing table by collecting network requests from all related
+        requirer databags. If there are errors or invalid network definitions in
+        the databags, they will be raised here, but must be fixed in the requirer
+        charm.
+
+        Raises:
+            JSONDecodeError:
+                The json from the databag was not decodable
+            RuntimeError:
+                There was an error with verifying the network request.
         """
         router_relations = self.model.relations[self.relation_name]
         final_routing_table: RoutingTable = {}
-        for relation in router_relations:
-            new_network_name = relation.data[relation.app].get("network-name", None)
-            new_network_request: List[Network] = json.loads(
-                relation.data[relation.app].get("networks", "{}")
-            )
 
-            if (
-                not new_network_name
-                or not new_network_request
-                or _network_name_taken(new_network_name, router_relations)
-            ):
+        for relation in router_relations:
+            try:
+                network_requests: RoutingTable = json.loads(
+                    relation.data[relation.app].get("networks")
+                )
+            except json.decoder.JSONDecodeError as e:
+                logger.error(
+                    "Failed parsing JSON from app %s databag. Skipping all networks from this app. %s",
+                    relation.app.name,
+                    relation.data[relation.app],
+                )
+                continue
+            except TypeError as e:
                 continue
 
-            final_routing_table[new_network_name] = []
-
-            for network in new_network_request:
-                try:
-                    _validate_network(network, final_routing_table)
-                except (ValueError, KeyError) as e:
-                    logger.error(
-                        "Exception (%s) occurred with network %s. Skipping this entry.",
-                        e.args[0],
-                        network,
+            for new_network_name, new_network in network_requests.items():
+                if not new_network_name or not new_network:
+                    continue
+                if new_network_name in final_routing_table.keys():
+                    error_string = (
+                        "Duplicate network name %s detected at least from second application %s, probably due to a race condition. Please make sure your network names are unique between applications.",
+                        new_network_name,
+                        relation.app.name,
                     )
+                    logger.error(error_string)
+                    raise RuntimeError(error_string)
+
+                try:
+                    _validate_network(new_network, final_routing_table)
+                except (ValueError, KeyError) as e:
+                    error_string = (
+                        "Exception (%s) occurred with network %s. This exception should be fixed at the requirer side.",
+                        e.args[0],
+                        new_network,
+                    )
+                    logger.error(error_string)
+                    raise RuntimeError(error_string)
                 else:
-                    final_routing_table[new_network_name].append(network)
+                    final_routing_table[new_network_name] = new_network
                     logger.debug(
                         "Added (%s) from app:(%s) with relation-name:(%s)",
-                        new_network_request,
+                        new_network_name,
                         relation.app.name,
                         new_network_name,
                     )
@@ -354,34 +362,8 @@ class RouterProvides(Object):
         logger.debug("Generated rt: %s", final_routing_table)
         return final_routing_table
 
-    def get_flattened_routing_table(self) -> List[Network]:
-        """Returns a read-only routing table that's flattened to fit the specification.
-        The routing table is in the form of
-        {
-            app1_name: list_of_networks_1,
-            app2_name: list_of_networks_2,
-            ...
-        }
-
-        A flattened table looks like
-        [
-            *list_of_networks_1,
-            *list_of_networks_2,
-            ...
-        ]
-
-        Returns:
-            A list of objects of type `Network`
-        """
-        internal_routing_table = self.get_routing_table()
-        final_routing_table: List[Network] = []
-        for networks in internal_routing_table.values():
-            final_routing_table.extend(networks)
-        logger.debug("Flattened RT to %s", final_routing_table)
-        return final_routing_table
-
     def _sync_routing_tables(self) -> None:
-        """Syncs the internal routing table with all of the requirer's app databags"""
+        """Syncs the internal routing table with all of the requirer's app databags."""
         routing_table = self.get_routing_table()
         for relation in self.model.relations[self.relation_name]:
             relation.data[self.charm.app].update({"networks": json.dumps(routing_table)})
@@ -389,14 +371,25 @@ class RouterProvides(Object):
 
 
 class RouterRequires(Object):
-    """ip-router requirer class to be instantiated by charms that require routing
+    """This class is used by ip-router requirers to create new network requests.
+    This requested network will be uniquely assigned to the requirer that created
+    it by the router provider, and it will also be broadcast to all of the other
+    ip-router requirer's databags by the ip-router provider.
 
-    This class provides methods to request a new network, and read the available
-    network from the router providers. These should be used exclusively to
-    interact with the relation.
+    At the same time, this class also provides the ability to get all of the other
+    networks that were assigned by the ip-router provider. A collective routing
+    table is created by the ip-router provider, which can be accessed at any
+    time from this class, or from listening to the `routing_table_updated` event.
+
+    This library can be used to share a routing table with assigned IP's between
+    multiple requirer charms, but the actual implementation of the pathing between
+    IP's is left to the provider and requirer charms themselves.
 
     Attributes:
-        charm: The Charm object that instantiates this class.
+        charm:
+            The Charm object that instantiates this class.
+        relation_name:
+            The name used for the relation implementing the ip-router interface.
     """
 
     on = RouterRequirerCharmEvents()
@@ -413,53 +406,48 @@ class RouterRequires(Object):
         new_table = self.get_routing_table()
         self.on.routing_table_updated.emit({"networks": new_table})
 
-    def request_network(
-        self, requested_networks: List[Network], custom_network_name: str = None
-    ) -> None:
-        """Requests a new network interface from the ip-router provider
-
-        The interfaces must be valid according to `_network_is_valid`. Multiple
+    def request_network(self, requested_networks: RoutingTable) -> None:
+        """Requests a set of new networks from the ip-router provider. Multiple
         calls to this function will replace the previously requested networks,
-        so all of the networks required must be given with each call.
+        so all of the networks required must be given with each call. If successful,
+        the provider will reserve this network for the charm and broadcast the
+        availability of this network to all other requirers.
 
         Arguments:
-            networks:
-                A list containing the desired networks of the type `Network`.
-            custom_network_name:
-                A string to use as the name of the network. Defaults to the relation
-                name.
+            requested_networks:
+                An object of type RoutingTable that the requirer wants from the
+                router to assign to itself, as well as broadcast to other requirers.
 
         Raises:
-            RuntimeError:
-                No ip-router relation exists yet or validation of one
-            or more of the networks failed.
+            ValueError:
+                Validation of one or more of the networks failed.
+            KeyError:
+                Validation of one or more of the networks failed.
         """
         if not self.charm.unit.is_leader():
             return
 
         ip_router_relations = self.model.relations.get(self.relation_name)
         if len(ip_router_relations) == 0:
-            raise RuntimeError("No ip-router relation exists yet.")
+            return
 
-        try:
-            existing_routing_table = self.get_routing_table()
-            existing_routing_table.pop(custom_network_name, None)
-            for i, network_request in enumerate(requested_networks):
-                other_requested_networks = requested_networks[i + 1 :]
+        existing_routing_table = self.get_routing_table()
+        [existing_routing_table.pop(key, None) for key in requested_networks.keys()]
+
+        for network_name, network_request in requested_networks.items():
+            try:
                 _validate_network(network_request, existing_routing_table)
-                _validate_network(
-                    network_request, {"other-requested-networks": other_requested_networks}
+            except (ValueError, KeyError) as e:
+                logger.error(
+                    "Exception (%s) occurred with network request. No routes were added.",
+                    e.args[0],
                 )
-        except (ValueError, KeyError) as e:
-            logger.error(
-                "Exception (%s) occurred with network request. No routes were added.", e.args[0]
-            )
-            raise
+                raise
+            else:
+                existing_routing_table[network_name] = network_request
 
         for relation in ip_router_relations:
-            network_name = custom_network_name if custom_network_name else relation.name
             relation.data[self.charm.app].update({"networks": json.dumps(requested_networks)})
-            relation.data[self.charm.app].update({"network-name": network_name})
         logger.debug(
             "Requested new network from the routers %s",
             str([r.name for r in ip_router_relations]),
@@ -478,25 +466,25 @@ class RouterRequires(Object):
         validated_routing_table: RoutingTable = {}
         for relation in router_relations:
             if relation_data := relation.data[relation.app].get("networks"):
-                routing_table_from_databag: RoutingTable = json.loads(relation_data)
-                if not isinstance(routing_table_from_databag, dict):
+                try:
+                    routing_table_from_databag: RoutingTable = json.loads(relation_data)
+                except json.decoder.JSONDecodeError:
                     logger.error(
-                        "The router's routing table has been misconfigured. Can't build routing table."
+                        "The router's databag has been misconfigured. Can't build routing table."
                     )
                     return {}
-                for network_name, networks in routing_table_from_databag.items():
-                    validated_routing_table[network_name] = []
-                    for network in networks:
-                        try:
-                            _validate_network(network, validated_routing_table)
-                        except (ValueError, KeyError) as e:
-                            logger.warning(
-                                "Malformed network detected in the databag:\nNetwork: (%s)\nError: (%s)",
-                                network,
-                                e.args[0],
-                            )
-                        else:
-                            validated_routing_table[network_name].append(network)
+
+                for network_name, network_entry in routing_table_from_databag.items():
+                    try:
+                        _validate_network(network_entry, validated_routing_table)
+                    except (ValueError, KeyError) as e:
+                        logger.warning(
+                            "Malformed network detected in the databag:\nNetwork: (%s)\nError: (%s)",
+                            network_entry,
+                            e.args[0],
+                        )
+                    else:
+                        validated_routing_table[network_name] = network_entry
                 logger.debug(
                     "Read networks from app: (%s) and relation: (%s)",
                     relation.app.name,
@@ -504,41 +492,10 @@ class RouterRequires(Object):
                 )
         return validated_routing_table
 
-    def get_all_networks(self) -> List[Network]:
-        """Fetches combined routing tables made available by ip-router providers
+    def get_network(self, network_name: str):
+        """Fetches the network configuration of a specific network.
 
-        Returns:
-            A list of objects of type `Network`. This list contains networks
-            from all ip-router providers that are integrated with the charm.
-        """
-        if not self.charm.unit.is_leader():
-            return
-
-        router_relations = self.model.relations.get(self.relation_name)
-        all_networks = []
-        for relation in router_relations:
-            if relation_data := relation.data[relation.app].get("networks"):
-                routing_table_from_databag: RoutingTable = json.loads(relation_data)
-                if not isinstance(routing_table_from_databag, dict):
-                    logger.error(
-                        "The router's routing table has been misconfigured. Can't build routing table."
-                    )
-                    return
-                for _, networks in routing_table_from_databag.items():
-                    for network in networks:
-                        try:
-                            _validate_network(network, {"existing-networks": all_networks})
-                        except (ValueError, KeyError) as e:
-                            logger.warning(
-                                "Malformed network detected in the databag:\nNetwork: (%s)\nError: (%s)",
-                                network,
-                                e.args[0],
-                            )
-                        else:
-                            all_networks.append(network)
-                logger.debug(
-                    "Read networks from app: (%s) and relation: (%s)",
-                    relation.app.name,
-                    self.relation_name,
-                )
-        return all_networks
+        Args:
+            network_name:
+                The requested network name"""
+        return self.get_routing_table()[network_name]

--- a/lib/charms/ip_router_interface/v0/ip_router_interface.py
+++ b/lib/charms/ip_router_interface/v0/ip_router_interface.py
@@ -414,7 +414,9 @@ class RouterRequires(Object):
         new_table = self.get_routing_table()
         self.on.routing_table_updated.emit({"networks": new_table})
 
-    def request_network(self, networks: List[Network], custom_network_name: str = None) -> None:
+    def request_network(
+        self, requested_networks: List[Network], custom_network_name: str = None
+    ) -> None:
         """Requests a new network interface from the ip-router provider
 
         The interfaces must be valid according to `_network_is_valid`. Multiple
@@ -441,8 +443,8 @@ class RouterRequires(Object):
             raise RuntimeError("No ip-router relation exists yet.")
 
         existing_routing_table = self.get_routing_table()
-        for i, network_request in enumerate(networks):
-            other_requested_networks = networks[:i] + networks[i + 1 :]
+        for i, network_request in enumerate(requested_networks):
+            other_requested_networks = requested_networks[:i] + requested_networks[i + 1 :]
             _validate_network(network_request, existing_routing_table)
             _validate_network(
                 network_request, {"other-requested-networks": other_requested_networks}
@@ -450,7 +452,7 @@ class RouterRequires(Object):
 
         for relation in ip_router_relations:
             network_name = custom_network_name if custom_network_name else relation.name
-            relation.data[self.charm.app].update({"networks": json.dumps(networks)})
+            relation.data[self.charm.app].update({"networks": json.dumps(requested_networks)})
             relation.data[self.charm.app].update({"network-name": network_name})
         logger.debug(
             "Requested new network from the routers %s",

--- a/lib/charms/ip_router_interface/v0/ip_router_interface.py
+++ b/lib/charms/ip_router_interface/v0/ip_router_interface.py
@@ -524,7 +524,7 @@ class RouterRequires(Object):
                         else:
                             all_networks.append(network)
                 logger.debug(
-                    f"Read networks from app: (%s) and relation: (%s)",
+                    "Read networks from app: (%s) and relation: (%s)",
                     relation.app.name,
                     self.relationship_name,
                 )

--- a/lib/charms/ip_router_interface/v0/ip_router_interface.py
+++ b/lib/charms/ip_router_interface/v0/ip_router_interface.py
@@ -135,7 +135,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 2
+LIBPATCH = 3
 
 from ipaddress import IPv4Address, IPv4Network
 from typing import Dict, List, Union, TypeAlias

--- a/lib/charms/ip_router_interface/v0/ip_router_interface.py
+++ b/lib/charms/ip_router_interface/v0/ip_router_interface.py
@@ -499,5 +499,8 @@ class RouterRequires(Object):
             network_name:
                 The requested network name
         Returns:
-            An object of type Network"""
+            An object of type Network
+        Raises:
+            KeyError: 
+               Will raise if the network_name does not yet exist in the routing table"""
         return self.get_routing_table()[network_name]

--- a/lib/charms/ip_router_interface/v0/ip_router_interface.py
+++ b/lib/charms/ip_router_interface/v0/ip_router_interface.py
@@ -492,10 +492,12 @@ class RouterRequires(Object):
                 )
         return validated_routing_table
 
-    def get_network(self, network_name: str):
+    def get_network(self, network_name: str) -> Network:
         """Fetches the network configuration of a specific network.
 
         Args:
             network_name:
-                The requested network name"""
+                The requested network name
+        Returns:
+            An object of type Network"""
         return self.get_routing_table()[network_name]

--- a/lib/charms/ip_router_interface/v0/ip_router_interface.py
+++ b/lib/charms/ip_router_interface/v0/ip_router_interface.py
@@ -440,8 +440,13 @@ class RouterRequires(Object):
         if len(ip_router_relations) == 0:
             raise RuntimeError("No ip-router relation exists yet.")
 
-        for network_request in networks:
-            _validate_network(network_request, self.get_routing_table())
+        existing_routing_table = self.get_routing_table()
+        for i, network_request in enumerate(networks):
+            other_requested_networks = networks[:i] + networks[i + 1 :]
+            _validate_network(network_request, existing_routing_table)
+            _validate_network(
+                network_request, {"other-requested-networks": other_requested_networks}
+            )
 
         for relation in ip_router_relations:
             network_name = custom_network_name if custom_network_name else relation.name

--- a/tests/integration/v0/test_integration.py
+++ b/tests/integration/v0/test_integration.py
@@ -129,7 +129,7 @@ class TestIntegration:
             timeout=1000,
         )
         await ops_test.model.integrate(
-            relation1=f"{IP_ROUTER_REQUIRER_APP_NAME}-b:{IP_ROUTER_REQUIRER_RELATION_NAME}-b",
+            relation1=f"{IP_ROUTER_REQUIRER_APP_NAME}-b:{IP_ROUTER_REQUIRER_RELATION_NAME}",
             relation2=f"{IP_ROUTER_PROVIDER_APP_NAME}:{IP_ROUTER_PROVIDER_RELATION_NAME}",
         )
         await ops_test.model.wait_for_idle(

--- a/tests/integration/v0/test_integration.py
+++ b/tests/integration/v0/test_integration.py
@@ -142,7 +142,7 @@ class TestIntegration:
             timeout=1000,
         )
         provider_unit = ops_test.model.units[f"{IP_ROUTER_PROVIDER_APP_NAME}/0"]
-        expected_rt = {"example-host": {"network": "192.168.250.0/24", "gateway": "192.168.250.1"}}
+        expected_rt = {"network-a": {"network": "192.168.250.0/24", "gateway": "192.168.250.1"}}
         await validate_routing_table(provider_unit, expected_rt, ops_test)
 
         requirer_unit_1 = ops_test.model.units[f"{IP_ROUTER_REQUIRER_APP_NAME}/0"]
@@ -150,7 +150,7 @@ class TestIntegration:
 
         # requirer1 sends a network request
         requested_network = {
-            "example-host": {"network": "192.168.251.0/24", "gateway": "192.168.251.1"}
+            "network-b": {"network": "192.168.251.0/24", "gateway": "192.168.251.1"}
         }
         await requirer_unit_1.run_action(
             action_name="request-network", network=json.dumps(requested_network)
@@ -169,13 +169,13 @@ class TestIntegration:
 
         # assert there is a new network in all charms
         expected_rt = {
-            "example-host": [{"network": "192.168.251.0/24", "gateway": "192.168.251.1"}],
+            "network-b": {"network": "192.168.251.0/24", "gateway": "192.168.251.1"},
         }
         await validate_routing_table(provider_unit, expected_rt, ops_test)
 
         # requirer2 sends a network request
         requested_network = {
-            "example-host-b": {"network": "192.168.252.0/24", "gateway": "192.168.252.1"}
+            "network-c": {"network": "192.168.252.0/24", "gateway": "192.168.252.1"}
         }
         await requirer_unit_2.run_action(
             action_name="request-network", network=json.dumps(requested_network)
@@ -193,8 +193,8 @@ class TestIntegration:
         )
 
         expected_rt = {
-            "example-host": {"network": "192.168.251.0/24", "gateway": "192.168.251.1"},
-            "example-host-b": {"network": "192.168.252.0/24", "gateway": "192.168.252.1"},
+            "network-b": {"network": "192.168.251.0/24", "gateway": "192.168.251.1"},
+            "network-c": {"network": "192.168.252.0/24", "gateway": "192.168.252.1"},
         }
 
         await validate_routing_table(provider_unit, expected_rt, ops_test)

--- a/tests/integration/v0/test_integration.py
+++ b/tests/integration/v0/test_integration.py
@@ -87,7 +87,9 @@ class TestIntegration:
         requirer_unit = ops_test.model.units[f"{IP_ROUTER_REQUIRER_APP_NAME}/0"]
 
         # Run a "request-network" action on the requirer charm
-        requested_network = [{"network": "192.168.250.0/24", "gateway": "192.168.250.1"}]
+        requested_network = {
+            "network-a": {"network": "192.168.250.0/24", "gateway": "192.168.250.1"}
+        }
         action = await requirer_unit.run_action(
             action_name="request-network", network=json.dumps(requested_network)
         )
@@ -105,7 +107,7 @@ class TestIntegration:
 
         # Run a "get-routing-table" action on the provider charm
         provider_unit = ops_test.model.units[f"{IP_ROUTER_PROVIDER_APP_NAME}/0"]
-        action = await provider_unit.run_action(action_name="get-flattened-routing-table")
+        action = await provider_unit.run_action(action_name="get-routing-table")
         action_output = await ops_test.model.get_action_output(
             action_uuid=action.entity_id, wait=60
         )
@@ -140,16 +142,16 @@ class TestIntegration:
             timeout=1000,
         )
         provider_unit = ops_test.model.units[f"{IP_ROUTER_PROVIDER_APP_NAME}/0"]
-        expected_rt = {
-            "example-host": [{"network": "192.168.250.0/24", "gateway": "192.168.250.1"}]
-        }
+        expected_rt = {"example-host": {"network": "192.168.250.0/24", "gateway": "192.168.250.1"}}
         await validate_routing_table(provider_unit, expected_rt, ops_test)
 
         requirer_unit_1 = ops_test.model.units[f"{IP_ROUTER_REQUIRER_APP_NAME}/0"]
         requirer_unit_2 = ops_test.model.units[f"{IP_ROUTER_REQUIRER_APP_NAME}-b/0"]
 
         # requirer1 sends a network request
-        requested_network = [{"network": "192.168.251.0/24", "gateway": "192.168.251.1"}]
+        requested_network = {
+            "example-host": {"network": "192.168.251.0/24", "gateway": "192.168.251.1"}
+        }
         await requirer_unit_1.run_action(
             action_name="request-network", network=json.dumps(requested_network)
         )
@@ -166,18 +168,15 @@ class TestIntegration:
         )
 
         # assert there is a new network in all charms
-        expected_flat_table = [
-            {"network": "192.168.251.0/24", "gateway": "192.168.251.1"},
-        ]
         expected_rt = {
             "example-host": [{"network": "192.168.251.0/24", "gateway": "192.168.251.1"}],
         }
         await validate_routing_table(provider_unit, expected_rt, ops_test)
-        await validate_routing_table(requirer_unit_1, expected_flat_table, ops_test)
-        await validate_routing_table(requirer_unit_2, expected_flat_table, ops_test)
 
         # requirer2 sends a network request
-        requested_network = [{"network": "192.168.252.0/24", "gateway": "192.168.252.1"}]
+        requested_network = {
+            "example-host-b": {"network": "192.168.252.0/24", "gateway": "192.168.252.1"}
+        }
         await requirer_unit_2.run_action(
             action_name="request-network", network=json.dumps(requested_network)
         )
@@ -193,15 +192,9 @@ class TestIntegration:
             timeout=1000,
         )
 
-        expected_flat_table = [
-            {"network": "192.168.251.0/24", "gateway": "192.168.251.1"},
-            {"network": "192.168.252.0/24", "gateway": "192.168.252.1"},
-        ]
         expected_rt = {
-            "example-host": [{"network": "192.168.251.0/24", "gateway": "192.168.251.1"}],
-            "example-host-b": [{"network": "192.168.252.0/24", "gateway": "192.168.252.1"}],
+            "example-host": {"network": "192.168.251.0/24", "gateway": "192.168.251.1"},
+            "example-host-b": {"network": "192.168.252.0/24", "gateway": "192.168.252.1"},
         }
 
         await validate_routing_table(provider_unit, expected_rt, ops_test)
-        await validate_routing_table(requirer_unit_1, expected_flat_table, ops_test)
-        await validate_routing_table(requirer_unit_2, expected_flat_table, ops_test)

--- a/tests/provider_charm/actions.yaml
+++ b/tests/provider_charm/actions.yaml
@@ -1,5 +1,2 @@
 get-routing-table:
   description: get the current routing table
-
-get-flattened-routing-table:
-  description: get the flattened routing table

--- a/tests/provider_charm/src/charm.py
+++ b/tests/provider_charm/src/charm.py
@@ -39,9 +39,6 @@ class SimpleIPRouteProviderCharm(ops.CharmBase):
             self.on[IP_ROUTER_PROVIDER_RELATION_NAME].relation_joined, self._on_relation_joined
         )
         self.framework.observe(self.on.get_routing_table_action, self._action_get_routing_table)
-        self.framework.observe(
-            self.on.get_flattened_routing_table_action, self._action_get_flattened_routing_table
-        )
 
     def _on_install(self, event: ops.InstallEvent):
         self.unit.status = ops.BlockedStatus("Waiting for relation to be created")

--- a/tests/provider_charm/src/charm.py
+++ b/tests/provider_charm/src/charm.py
@@ -50,10 +50,6 @@ class SimpleIPRouteProviderCharm(ops.CharmBase):
         rt = self.RouterProvider.get_routing_table()
         event.set_results({"msg": json.dumps(rt)})
 
-    def _action_get_flattened_routing_table(self, event: ops.ActionEvent):
-        rt = self.RouterProvider.get_flattened_routing_table()
-        event.set_results({"msg": json.dumps(rt)})
-
 
 if __name__ == "__main__":
     ops.main.main(SimpleIPRouteProviderCharm)

--- a/tests/provider_charm/src/charm.py
+++ b/tests/provider_charm/src/charm.py
@@ -32,7 +32,7 @@ class SimpleIPRouteProviderCharm(ops.CharmBase):
     def __init__(self, *args):
         super().__init__(*args)
         self.RouterProvider = RouterProvides(
-            charm=self, relationship_name=IP_ROUTER_PROVIDER_RELATION_NAME
+            charm=self, relation_name=IP_ROUTER_PROVIDER_RELATION_NAME
         )
         self.framework.observe(self.on.install, self._on_install)
         self.framework.observe(

--- a/tests/requirer_charm/src/charm.py
+++ b/tests/requirer_charm/src/charm.py
@@ -31,10 +31,10 @@ class SimpleIPRouteRequirerCharm(ops.CharmBase):
     def __init__(self, *args):
         super().__init__(*args)
         self.RouterRequirer = RouterRequires(
-            charm=self, relationship_name=f"{IP_ROUTER_REQUIRER_RELATION_NAME}"
+            charm=self, relation_name=f"{IP_ROUTER_REQUIRER_RELATION_NAME}"
         )
         self.RouterRequirer_B = RouterRequires(
-            charm=self, relationship_name=f"{IP_ROUTER_REQUIRER_RELATION_NAME}-b"
+            charm=self, relation_name=f"{IP_ROUTER_REQUIRER_RELATION_NAME}-b"
         )
         self.framework.observe(self.on.install, self._on_install)
         self.framework.observe(

--- a/tests/requirer_charm/src/charm.py
+++ b/tests/requirer_charm/src/charm.py
@@ -33,16 +33,9 @@ class SimpleIPRouteRequirerCharm(ops.CharmBase):
         self.RouterRequirer = RouterRequires(
             charm=self, relation_name=f"{IP_ROUTER_REQUIRER_RELATION_NAME}"
         )
-        self.RouterRequirer_B = RouterRequires(
-            charm=self, relation_name=f"{IP_ROUTER_REQUIRER_RELATION_NAME}-b"
-        )
         self.framework.observe(self.on.install, self._on_install)
         self.framework.observe(
             self.on[IP_ROUTER_REQUIRER_RELATION_NAME].relation_joined,
-            self._on_relation_joined,
-        )
-        self.framework.observe(
-            self.on[f"{IP_ROUTER_REQUIRER_RELATION_NAME}-b"].relation_joined,
             self._on_relation_joined,
         )
 
@@ -56,17 +49,11 @@ class SimpleIPRouteRequirerCharm(ops.CharmBase):
         self.unit.status = ops.ActiveStatus("Ready to Require")
 
     def _action_get_routing_table(self, event: ops.ActionEvent):
-        if self.app.name[-1] == "b":
-            rt = self.RouterRequirer_B.get_all_networks()
-        else:
-            rt = self.RouterRequirer.get_all_networks()
+        rt = self.RouterRequirer.get_all_networks()
         event.set_results({"msg": json.dumps(rt)})
 
     def _action_request_network(self, event: ops.ActionEvent):
-        if self.app.name[-1] == "b":
-            self.RouterRequirer_B.request_network(json.loads(event.params["network"]))
-        else:
-            self.RouterRequirer.request_network(json.loads(event.params["network"]))
+        self.RouterRequirer.request_network(json.loads(event.params["network"]))
         event.set_results({"msg": "ok"})
 
 

--- a/tests/unit/ip_router_interface/v0/test_ip_router.py
+++ b/tests/unit/ip_router_interface/v0/test_ip_router.py
@@ -49,66 +49,53 @@ class TestProvider(unittest.TestCase):
         rel_id = self.harness.add_relation(IP_ROUTER_PROVIDER_RELATION_NAME, "ip-router-requirer")
         self.harness.add_relation_unit(rel_id, "ip-router-requirer/0")
 
-        network_request = [{"network": "192.168.250.0/24", "gateway": "192.168.250.1"}]
+        network_request = {
+            IP_ROUTER_REQUIRER_RELATION_NAME: {
+                "network": "192.168.250.0/24",
+                "gateway": "192.168.250.1",
+            }
+        }
         self.harness.update_relation_data(
             rel_id, "ip-router-requirer", {"networks": json.dumps(network_request)}
         )
-        self.harness.update_relation_data(
-            rel_id, "ip-router-requirer", {"network-name": IP_ROUTER_REQUIRER_RELATION_NAME}
-        )
 
-        expected_rt = {IP_ROUTER_REQUIRER_RELATION_NAME: network_request}
-        assert self.harness.charm.RouterProvider.get_routing_table() == expected_rt
-        expected_databag = {"networks": json.dumps(expected_rt)}
-        assert (
-            self.harness.get_relation_data(rel_id, self.harness.charm.app.name) == expected_databag
-        )
+        assert self.harness.charm.RouterProvider.get_routing_table() == network_request
 
     def test_given_provider_when_network_request_with_provider_received_then_adds_network(self):
         rel_id = self.harness.add_relation(IP_ROUTER_PROVIDER_RELATION_NAME, "ip-router-requirer")
         self.harness.add_relation_unit(rel_id, "ip-router-requirer/0")
 
-        network_request = [
-            {
+        network_request = {
+            IP_ROUTER_REQUIRER_RELATION_NAME: {
                 "network": "192.168.250.0/24",
                 "gateway": "192.168.250.1",
                 "routes": [{"destination": "172.250.0.0/16", "gateway": "192.168.250.3"}],
             }
-        ]
+        }
         self.harness.update_relation_data(
             rel_id, "ip-router-requirer", {"networks": json.dumps(network_request)}
         )
-        self.harness.update_relation_data(
-            rel_id, "ip-router-requirer", {"network-name": IP_ROUTER_REQUIRER_RELATION_NAME}
-        )
 
-        expected_rt = {IP_ROUTER_REQUIRER_RELATION_NAME: network_request}
-        assert self.harness.charm.RouterProvider.get_routing_table() == expected_rt
-        expected_databag = {"networks": json.dumps(expected_rt)}
-        assert (
-            self.harness.get_relation_data(rel_id, self.harness.charm.app.name) == expected_databag
-        )
+        assert self.harness.charm.RouterProvider.get_routing_table() == network_request
 
     def test_given_provider_when_multiple_network_requests_received_then_adds_networks(self):
         rel_id = self.harness.add_relation(IP_ROUTER_PROVIDER_RELATION_NAME, "ip-router-requirer")
         self.harness.add_relation_unit(rel_id, "ip-router-requirer/0")
 
-        network_request = [
-            {"network": "192.168.250.0/24", "gateway": "192.168.250.1"},
-            {"network": "192.168.251.0/24", "gateway": "192.168.251.1"},
-        ]
+        network_request = {
+            f"{IP_ROUTER_REQUIRER_RELATION_NAME}-a": {
+                "network": "192.168.250.0/24",
+                "gateway": "192.168.250.1",
+            },
+            f"{IP_ROUTER_REQUIRER_RELATION_NAME}-b": {
+                "network": "192.168.251.0/24",
+                "gateway": "192.168.251.1",
+            },
+        }
         self.harness.update_relation_data(
             rel_id, "ip-router-requirer", {"networks": json.dumps(network_request)}
         )
-        self.harness.update_relation_data(
-            rel_id, "ip-router-requirer", {"network-name": IP_ROUTER_REQUIRER_RELATION_NAME}
-        )
-        expected_rt = {IP_ROUTER_REQUIRER_RELATION_NAME: network_request}
-        assert self.harness.charm.RouterProvider.get_routing_table() == expected_rt
-        expected_databag = {"networks": json.dumps(expected_rt)}
-        assert (
-            self.harness.get_relation_data(rel_id, self.harness.charm.app.name) == expected_databag
-        )
+        assert self.harness.charm.RouterProvider.get_routing_table() == network_request
 
     def test_given_provider_when_requests_from_multiple_relations_then_adds_networks(self):
         rel_a_id = self.harness.add_relation(
@@ -126,60 +113,41 @@ class TestProvider(unittest.TestCase):
         )
         self.harness.add_relation_unit(rel_c_id, "ip-router-requirer-c/0")
 
-        network_request_a = [
-            {
+        network_request_a = {
+            f"{IP_ROUTER_REQUIRER_RELATION_NAME}-a": {
                 "network": "192.168.250.0/24",
                 "gateway": "192.168.250.1",
                 "routes": [{"destination": "172.250.0.0/16", "gateway": "192.168.250.3"}],
             }
-        ]
+        }
 
         self.harness.update_relation_data(
             rel_a_id, "ip-router-requirer-a", {"networks": json.dumps(network_request_a)}
         )
-        self.harness.update_relation_data(
-            rel_a_id,
-            "ip-router-requirer-a",
-            {"network-name": f"{IP_ROUTER_REQUIRER_RELATION_NAME}-a"},
-        )
 
-        network_request_b = [
-            {
+        network_request_b = {
+            f"{IP_ROUTER_REQUIRER_RELATION_NAME}-b": {
                 "network": "192.168.252.0/24",
                 "gateway": "192.168.252.1",
             }
-        ]
+        }
 
         self.harness.update_relation_data(
             rel_b_id, "ip-router-requirer-b", {"networks": json.dumps(network_request_b)}
         )
-        self.harness.update_relation_data(
-            rel_b_id,
-            "ip-router-requirer-b",
-            {"network-name": f"{IP_ROUTER_REQUIRER_RELATION_NAME}-b"},
-        )
 
-        network_request_c = [
-            {
+        network_request_c = {
+            f"{IP_ROUTER_REQUIRER_RELATION_NAME}-c": {
                 "network": "192.168.251.0/24",
                 "gateway": "192.168.251.1",
             }
-        ]
+        }
 
         self.harness.update_relation_data(
             rel_c_id, "ip-router-requirer-c", {"networks": json.dumps(network_request_c)}
         )
-        self.harness.update_relation_data(
-            rel_c_id,
-            "ip-router-requirer-c",
-            {"network-name": f"{IP_ROUTER_REQUIRER_RELATION_NAME}-c"},
-        )
 
-        expected_rt = {
-            f"{IP_ROUTER_REQUIRER_RELATION_NAME}-a": network_request_a,
-            f"{IP_ROUTER_REQUIRER_RELATION_NAME}-b": network_request_b,
-            f"{IP_ROUTER_REQUIRER_RELATION_NAME}-c": network_request_c,
-        }
+        expected_rt = dict(network_request_a | network_request_b | network_request_c)
         assert self.harness.charm.RouterProvider.get_routing_table() == expected_rt
         expected_databag = {"networks": json.dumps(expected_rt)}
         assert (
@@ -210,90 +178,83 @@ class TestRequirer(unittest.TestCase):
         rel_id = self.harness.add_relation(IP_ROUTER_REQUIRER_RELATION_NAME, "ip-router-provider")
         self.harness.add_relation_unit(rel_id, "ip-router-provider/0")
 
-        assert self.harness.charm.RouterRequirer.get_all_networks() == []
         assert self.harness.charm.RouterRequirer.get_routing_table() == {}
 
     def test_given_filled_routing_table_when_get_routing_table_then_gets_network_correctly(self):
         rel_id = self.harness.add_relation(IP_ROUTER_REQUIRER_RELATION_NAME, "ip-router-provider")
         self.harness.add_relation_unit(rel_id, "ip-router-provider/0")
 
-        existing_network = [
-            {
+        existing_network = {
+            "host-a": {
                 "network": "192.168.250.0/24",
                 "gateway": "192.168.250.1",
                 "routes": [{"destination": "172.250.0.0/16", "gateway": "192.168.250.3"}],
             },
-            {"network": "192.168.252.0/24", "gateway": "192.168.252.1"},
-            {"network": "192.168.251.0/24", "gateway": "192.168.251.1"},
-        ]
-        existing_rt = {IP_ROUTER_REQUIRER_RELATION_NAME: existing_network}
+            "host-b": {"network": "192.168.252.0/24", "gateway": "192.168.252.1"},
+            "host-c": {"network": "192.168.251.0/24", "gateway": "192.168.251.1"},
+        }
 
         self.harness.update_relation_data(
             rel_id,
             "ip-router-provider",
-            {"networks": json.dumps(existing_rt)},
+            {"networks": json.dumps(existing_network)},
         )
 
-        assert self.harness.charm.RouterRequirer.get_all_networks() == existing_network
-        assert self.harness.charm.RouterRequirer.get_routing_table() == existing_rt
+        assert self.harness.charm.RouterRequirer.get_routing_table() == existing_network
 
     def test_given_requirer_when_request_new_network_then_produces_correct_databag(self):
         rel_id = self.harness.add_relation(IP_ROUTER_REQUIRER_RELATION_NAME, "ip-router-provider")
         self.harness.add_relation_unit(rel_id, "ip-router-provider/0")
 
-        network_request = [
-            {
+        network_request = {
+            "host-a": {
                 "network": "192.168.252.0/24",
                 "gateway": "192.168.252.1",
             }
-        ]
+        }
         self.harness.charm.RouterRequirer.request_network(network_request)
 
         assert self.harness.get_relation_data(rel_id, "ip-router-requirer") == {
             "networks": json.dumps(network_request),
-            "network-name": IP_ROUTER_REQUIRER_RELATION_NAME,
         }
 
     def test_given_requirer_when_request_new_network_multiple_then_produces_correct_databag(self):
         rel_id = self.harness.add_relation(IP_ROUTER_REQUIRER_RELATION_NAME, "ip-router-provider")
         self.harness.add_relation_unit(rel_id, "ip-router-provider/0")
 
-        network_request = [
-            {"network": "192.168.252.0/24", "gateway": "192.168.252.1"},
-            {"network": "192.168.250.0/24", "gateway": "192.168.250.1"},
-        ]
+        network_request = {
+            "host-a": {"network": "192.168.252.0/24", "gateway": "192.168.252.1"},
+            "host-b": {"network": "192.168.250.0/24", "gateway": "192.168.250.1"},
+        }
         self.harness.charm.RouterRequirer.request_network(network_request)
 
         assert self.harness.get_relation_data(rel_id, "ip-router-requirer") == {
             "networks": json.dumps(network_request),
-            "network-name": IP_ROUTER_REQUIRER_RELATION_NAME,
         }
 
-    def test_given_requirer_when_request_new_network_missing_relation_then_raises_exception(self):
-        network_request = [
-            {
+    def test_given_requirer_when_request_new_network_missing_relation_then_returns_none(self):
+        network_request = {
+            "host-a": {
                 "network": "192.168.252.0/24",
                 "gateway": "192.168.252.1",
             }
-        ]
-        with self.assertRaises(RuntimeError):
-            self.harness.charm.RouterRequirer.request_network(network_request)
+        }
+        assert self.harness.charm.RouterRequirer.request_network(network_request) is None
 
     def test_given_requirer_when_request_new_network_with_ip_conflicts_then_raises_exception(self):
         rel_id = self.harness.add_relation(IP_ROUTER_REQUIRER_RELATION_NAME, "ip-router-provider")
         self.harness.add_relation_unit(rel_id, "ip-router-provider/0")
 
-        existing_network = [{"network": "192.168.252.0/24", "gateway": "192.168.252.1"}]
-        existing_rt = {IP_ROUTER_REQUIRER_RELATION_NAME: existing_network}
+        existing_network = {"host-a": {"network": "192.168.252.0/24", "gateway": "192.168.252.1"}}
         self.harness.update_relation_data(
             rel_id,
             "ip-router-provider",
-            {"networks": json.dumps(existing_rt)},
+            {"networks": json.dumps(existing_network)},
         )
 
-        network_request = [
-            {"network": "192.168.240.0/20", "gateway": "192.168.250.1"},
-        ]
+        network_request = {
+            "host-b": {"network": "192.168.240.0/20", "gateway": "192.168.250.1"},
+        }
         with self.assertRaises(ValueError):
             self.harness.charm.RouterRequirer.request_network(network_request)
 
@@ -305,19 +266,18 @@ class TestRequirer(unittest.TestCase):
         rel_id = self.harness.add_relation(IP_ROUTER_REQUIRER_RELATION_NAME, "ip-router-provider")
         self.harness.add_relation_unit(rel_id, "ip-router-provider/0")
 
-        existing_network = [{"network": "192.168.252.0/24", "gateway": "192.168.252.1"}]
-        existing_rt = {IP_ROUTER_REQUIRER_RELATION_NAME: existing_network}
+        existing_network = {"host-a": {"network": "192.168.252.0/24", "gateway": "192.168.252.1"}}
         self.harness.update_relation_data(
-            rel_id, "ip-router-provider", {"networks": json.dumps(existing_rt)}
+            rel_id, "ip-router-provider", {"networks": json.dumps(existing_network)}
         )
 
-        network_request = [
-            {
+        network_request = {
+            "host-b": {
                 "network": "192.168.250.0/24",
                 "gateway": "192.168.250.1",
                 "routes": [{"destination": "172.250.0.0/16", "gateway": "192.168.240.3"}],
             }
-        ]
+        }
         with self.assertRaises(ValueError):
             self.harness.charm.RouterRequirer.request_network(network_request)
         assert self.harness.get_relation_data(rel_id, "ip-router-requirer") == {}
@@ -328,22 +288,22 @@ class TestRequirer(unittest.TestCase):
         rel_id = self.harness.add_relation(IP_ROUTER_REQUIRER_RELATION_NAME, "ip-router-provider")
         self.harness.add_relation_unit(rel_id, "ip-router-provider/0")
 
-        existing_network = [{"network": "192.168.252.0/24", "gateway": "192.168.252.1"}]
+        existing_network = {"host-a": {"network": "192.168.252.0/24", "gateway": "192.168.252.1"}}
         self.harness.update_relation_data(
             rel_id, "ip-router-provider", {"networks": json.dumps(existing_network)}
         )
 
-        network_request = [
-            {
+        network_request = {
+            "host-b": {
                 "network": "192.168.250.0/24",
                 "gateway": "192.168.250.1",
                 "routes": [{"destination": "172.250.0.0/16", "gateway": "192.168.240.3"}],
             },
-            {
+            "host-c": {
                 "network": "192.168.251.0/24",
                 "gateway": "192.168.251.1",
             },
-        ]
+        }
         with self.assertRaises(ValueError):
             self.harness.charm.RouterRequirer.request_network(network_request)
         assert self.harness.get_relation_data(rel_id, "ip-router-requirer") == {}
@@ -352,9 +312,9 @@ class TestRequirer(unittest.TestCase):
         rel_id = self.harness.add_relation(IP_ROUTER_REQUIRER_RELATION_NAME, "ip-router-provider")
         self.harness.add_relation_unit(rel_id, "ip-router-provider/0")
 
-        network_request = [
-            {"network": "192.168.240.0/20", "sad": "192.168.250.1"},
-        ]
+        network_request = {
+            "host-a": {"network": "192.168.240.0/20", "sad": "192.168.250.1"},
+        }
         with self.assertRaises(KeyError):
             self.harness.charm.RouterRequirer.request_network(network_request)
 
@@ -364,9 +324,9 @@ class TestRequirer(unittest.TestCase):
         rel_id = self.harness.add_relation(IP_ROUTER_REQUIRER_RELATION_NAME, "ip-router-provider")
         self.harness.add_relation_unit(rel_id, "ip-router-provider/0")
 
-        network_request = [
-            {"sad": "192.168.240.0/20", "gateway": "192.168.250.1"},
-        ]
+        network_request = {
+            "host-a": {"sad": "192.168.240.0/20", "gateway": "192.168.250.1"},
+        }
         with self.assertRaises(KeyError):
             self.harness.charm.RouterRequirer.request_network(network_request)
 
@@ -378,13 +338,13 @@ class TestRequirer(unittest.TestCase):
         rel_id = self.harness.add_relation(IP_ROUTER_REQUIRER_RELATION_NAME, "ip-router-provider")
         self.harness.add_relation_unit(rel_id, "ip-router-provider/0")
 
-        network_request = [
-            {
+        network_request = {
+            "host-a": {
                 "network": "192.168.250.0/24",
                 "gateway": "192.168.250.1",
                 "routes": [{"destinope": "172.250.0.0/16", "gateway": "192.168.240.3"}],
             }
-        ]
+        }
         with self.assertRaises(KeyError):
             self.harness.charm.RouterRequirer.request_network(network_request)
 
@@ -394,13 +354,13 @@ class TestRequirer(unittest.TestCase):
         rel_id = self.harness.add_relation(IP_ROUTER_REQUIRER_RELATION_NAME, "ip-router-provider")
         self.harness.add_relation_unit(rel_id, "ip-router-provider/0")
 
-        network_request = [
-            {
+        network_request = {
+            "host-a": {
                 "network": "192.168.250.0/24",
                 "gateway": "192.168.250.1",
                 "routes": [{"destination": "172.250.0.0/16", "gateroad": "192.168.240.3"}],
             }
-        ]
+        }
         with self.assertRaises(KeyError):
             self.harness.charm.RouterRequirer.request_network(network_request)
         assert self.harness.get_relation_data(rel_id, "ip-router-requirer") == {}


### PR DESCRIPTION
# Description

This change makes it so that instead of transferring a list of available networks, the databag actually contains the names of the relations that the networks have originated from, which is crucial for requirers to be able to discern which network is coming from what.

## Checklist

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that validate the behaviour of the software.
- [x] I validated that new and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I have bumped the version of any required library.
